### PR TITLE
fix(devcontainer): update Azure CLI feature and remove obsolete .NET …

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,14 +2,11 @@
   "name": "TechWorkshop L300 - GitHub Copilot & Platform",
   "image": "mcr.microsoft.com/devcontainers/dotnet:1-8.0",
   "features": {
-    "ghcr.io/devcontainers/features/dotnet:2": {
-      "version": "6.0"
-    },
     "ghcr.io/devcontainers/features/azure-cli:1": {
       "version": "latest"
     },
-    "ghcr.io/azure/azure-dev/azd:0": {
-      "version": "latest"
+    "ghcr.io/azure/azure-dev/azd:latest": {
+      "extensions": "azure.coding-agent"
     }
   },
   "customizations": {


### PR DESCRIPTION
This pull request adds a new `.devcontainer/devcontainer.json` file to set up a development container for the project. The configuration specifies a .NET 8.0 environment, includes Azure CLI and Azure Dev tools, and pre-installs several VS Code extensions to support GitHub Copilot and Azure development.

**Development environment setup:**

* Added `.devcontainer/devcontainer.json` to define a dev container using the `mcr.microsoft.com/devcontainers/dotnet:1-8.0` image, ensuring a consistent .NET 8.0 development environment.
* Configured Azure CLI and Azure Dev (`azd`) features for streamlined cloud development workflows.
* Pre-installed VS Code extensions for GitHub Copilot, Copilot Chat, Azure, Bicep, and Docker to enhance productivity and cloud integration.
* Set up a `postCreateCommand` to automatically restore NuGet packages for the solution after container creation.