### PR TITLE
H2floh/chatfeature

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -92,20 +92,3 @@ jobs:
         with:
           app-name: ${{ env.APP_NAME }}
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
-
-      - name: Configure AI Foundry environment variables on App Service
-        if: env.AI_ENDPOINT != '' && env.AI_ENDPOINT != 'null'
-        run: |
-          # Retrieve the API key from the AI Services resource
-          AI_KEY=$(az cognitiveservices account keys list \
-            --name "${{ env.AI_NAME }}" \
-            --resource-group "${{ env.RESOURCE_GROUP }}" \
-            --query "key1" -o tsv)
-
-          az webapp config appsettings set \
-            --name "${{ env.APP_NAME }}" \
-            --resource-group "${{ env.RESOURCE_GROUP }}" \
-            --settings \
-              AzureAIFoundry__Endpoint="${{ env.AI_ENDPOINT }}" \
-              AzureAIFoundry__ApiKey="$AI_KEY" \
-              AzureAIFoundry__ModelName="Phi-4-mini-instruct"

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -66,14 +66,12 @@ jobs:
           REGISTRY=$(azd env get-values --output json | jq -r '.AZURE_CONTAINER_REGISTRY_ENDPOINT')
           APP_NAME=$(azd env get-values --output json | jq -r '.SERVICE_WEB_IMAGE_NAME')
           AI_ENDPOINT=$(azd env get-values --output json | jq -r '.AZURE_AI_FOUNDRY_ENDPOINT')
-          AI_NAME=$(azd env get-values --output json | jq -r '.AZURE_AI_FOUNDRY_NAME')
           RESOURCE_GROUP=$(azd env get-values --output json | jq -r '.AZURE_RESOURCE_GROUP')
           if [ -z "$REGISTRY" ] || [ "$REGISTRY" = "null" ]; then echo "::error::AZURE_CONTAINER_REGISTRY_ENDPOINT not found in azd environment"; exit 1; fi
           if [ -z "$APP_NAME" ] || [ "$APP_NAME" = "null" ]; then echo "::error::SERVICE_WEB_IMAGE_NAME not found in azd environment"; exit 1; fi
           echo "REGISTRY=$REGISTRY" >> "$GITHUB_ENV"
           echo "APP_NAME=$APP_NAME" >> "$GITHUB_ENV"
           echo "AI_ENDPOINT=$AI_ENDPOINT" >> "$GITHUB_ENV"
-          echo "AI_NAME=$AI_NAME" >> "$GITHUB_ENV"
           echo "RESOURCE_GROUP=$RESOURCE_GROUP" >> "$GITHUB_ENV"
         env:
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
@@ -92,3 +90,13 @@ jobs:
         with:
           app-name: ${{ env.APP_NAME }}
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+
+      - name: Configure AI Foundry endpoint on App Service
+        if: env.AI_ENDPOINT != '' && env.AI_ENDPOINT != 'null'
+        run: |
+          az webapp config appsettings set \
+            --name "${{ env.APP_NAME }}" \
+            --resource-group "${{ env.RESOURCE_GROUP }}" \
+            --settings \
+              AzureAIFoundry__Endpoint="${{ env.AI_ENDPOINT }}" \
+              AzureAIFoundry__ModelName="Phi-4-mini-instruct"

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -55,7 +55,7 @@ module appService 'modules/appService.bicep' = {
     containerRegistryId: acr.outputs.id
     appInsightsConnectionString: appInsights.outputs.connectionString
     imageName: 'web:latest'
-    aiFoundryEndpoint: aiFoundry.outputs.endpoint
+    aiFoundryEndpoint: aiFoundry.outputs.inferenceEndpoint
     aiFoundryApiKey: aiFoundry.outputs.apiKey
   }
 }
@@ -77,5 +77,5 @@ output AZURE_CONTAINER_REGISTRY_ENDPOINT string = acr.outputs.loginServer
 output SERVICE_WEB_IMAGE_NAME string = appService.outputs.name
 output AZURE_LOCATION string = location
 output AZURE_RESOURCE_GROUP string = rg.name
-output AZURE_AI_FOUNDRY_ENDPOINT string = aiFoundry.outputs.endpoint
+output AZURE_AI_FOUNDRY_ENDPOINT string = aiFoundry.outputs.inferenceEndpoint
 output AZURE_AI_FOUNDRY_NAME string = aiFoundry.outputs.name

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -56,7 +56,6 @@ module appService 'modules/appService.bicep' = {
     appInsightsConnectionString: appInsights.outputs.connectionString
     imageName: 'web:latest'
     aiFoundryEndpoint: aiFoundry.outputs.inferenceEndpoint
-    aiFoundryApiKey: aiFoundry.outputs.apiKey
   }
 }
 
@@ -68,6 +67,7 @@ module aiFoundry 'modules/aiFoundry.bicep' = {
     name: 'ai-${environmentName}-${resourceToken}'
     location: location
     tags: tags
+    webAppPrincipalId: appService.outputs.identityPrincipalId
   }
 }
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -56,6 +56,7 @@ module appService 'modules/appService.bicep' = {
     appInsightsConnectionString: appInsights.outputs.connectionString
     imageName: 'web:latest'
     aiFoundryEndpoint: aiFoundry.outputs.inferenceEndpoint
+    aiServicesId: aiFoundry.outputs.id
   }
 }
 
@@ -67,7 +68,6 @@ module aiFoundry 'modules/aiFoundry.bicep' = {
     name: 'ai-${environmentName}-${resourceToken}'
     location: location
     tags: tags
-    webAppPrincipalId: appService.outputs.identityPrincipalId
   }
 }
 

--- a/infra/modules/aiFoundry.bicep
+++ b/infra/modules/aiFoundry.bicep
@@ -60,8 +60,11 @@ resource phi4Deployment 'Microsoft.CognitiveServices/accounts/deployments@2024-0
   ]
 }
 
-@description('Endpoint URL for the Azure AI Services resource')
+@description('Endpoint URL for the Azure AI Services resource (standard Cognitive Services)')
 output endpoint string = aiServices.properties.endpoint
+
+@description('Model inference endpoint for Azure AI Inference SDK (services.ai.azure.com format)')
+output inferenceEndpoint string = 'https://${name}.services.ai.azure.com/'
 
 @description('Primary API key for the Azure AI Services resource')
 output apiKey string = aiServices.listKeys().key1

--- a/infra/modules/aiFoundry.bicep
+++ b/infra/modules/aiFoundry.bicep
@@ -64,7 +64,7 @@ resource phi4Deployment 'Microsoft.CognitiveServices/accounts/deployments@2024-0
 output endpoint string = aiServices.properties.endpoint
 
 @description('Model inference endpoint for Azure AI Inference SDK (services.ai.azure.com format)')
-output inferenceEndpoint string = 'https://${name}.services.ai.azure.com/'
+output inferenceEndpoint string = 'https://${name}.services.ai.azure.com/models'
 
 @description('Resource ID of the Azure AI Services resource')
 output id string = aiServices.id

--- a/infra/modules/aiFoundry.bicep
+++ b/infra/modules/aiFoundry.bicep
@@ -7,6 +7,9 @@ param location string
 @description('Tags to apply to the Azure AI Services resource')
 param tags object = {}
 
+@description('Principal ID of the Web App managed identity to grant inference access')
+param webAppPrincipalId string = ''
+
 // Azure AI Services (AI Foundry)
 resource aiServices 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
   name: name
@@ -60,14 +63,23 @@ resource phi4Deployment 'Microsoft.CognitiveServices/accounts/deployments@2024-0
   ]
 }
 
+// Role assignment: Grant "Cognitive Services User" to the Web App managed identity
+// This role (2dc56799-7e8d-46ac-b01e-a3ae1569d8bb) allows inference calls.
+resource cognitiveServicesUserRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(webAppPrincipalId)) {
+  name: guid(aiServices.id, webAppPrincipalId, 'CognitiveServicesUser')
+  scope: aiServices
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '2dc56799-7e8d-46ac-b01e-a3ae1569d8bb')
+    principalId: webAppPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
 @description('Endpoint URL for the Azure AI Services resource (standard Cognitive Services)')
 output endpoint string = aiServices.properties.endpoint
 
 @description('Model inference endpoint for Azure AI Inference SDK (services.ai.azure.com format)')
 output inferenceEndpoint string = 'https://${name}.services.ai.azure.com/'
-
-@description('Primary API key for the Azure AI Services resource')
-output apiKey string = aiServices.listKeys().key1
 
 @description('Resource ID of the Azure AI Services resource')
 output id string = aiServices.id

--- a/infra/modules/aiFoundry.bicep
+++ b/infra/modules/aiFoundry.bicep
@@ -7,9 +7,6 @@ param location string
 @description('Tags to apply to the Azure AI Services resource')
 param tags object = {}
 
-@description('Principal ID of the Web App managed identity to grant inference access')
-param webAppPrincipalId string = ''
-
 // Azure AI Services (AI Foundry)
 resource aiServices 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
   name: name
@@ -61,18 +58,6 @@ resource phi4Deployment 'Microsoft.CognitiveServices/accounts/deployments@2024-0
   dependsOn: [
     gpt41Deployment
   ]
-}
-
-// Role assignment: Grant "Cognitive Services User" to the Web App managed identity
-// This role (2dc56799-7e8d-46ac-b01e-a3ae1569d8bb) allows inference calls.
-resource cognitiveServicesUserRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(webAppPrincipalId)) {
-  name: guid(aiServices.id, webAppPrincipalId, 'CognitiveServicesUser')
-  scope: aiServices
-  properties: {
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '2dc56799-7e8d-46ac-b01e-a3ae1569d8bb')
-    principalId: webAppPrincipalId
-    principalType: 'ServicePrincipal'
-  }
 }
 
 @description('Endpoint URL for the Azure AI Services resource (standard Cognitive Services)')

--- a/infra/modules/appService.bicep
+++ b/infra/modules/appService.bicep
@@ -101,7 +101,7 @@ resource cognitiveServicesUserRole 'Microsoft.Authorization/roleAssignments@2022
   name: guid(aiServicesId, webApp.id, 'CognitiveServicesUser')
   scope: aiServicesResource
   properties: {
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '2dc56799-7e8d-46ac-b01e-a3ae1569d8bb')
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a97b65f3-24c7-4388-baec-2e87135dc908')
     principalId: webApp.identity.principalId
     principalType: 'ServicePrincipal'
   }

--- a/infra/modules/appService.bicep
+++ b/infra/modules/appService.bicep
@@ -22,10 +22,6 @@ param imageName string = 'zava-storefront:latest'
 @description('Azure AI Foundry endpoint URL')
 param aiFoundryEndpoint string = ''
 
-@description('Azure AI Foundry API key')
-@secure()
-param aiFoundryApiKey string = ''
-
 // App Service Plan
 resource appServicePlan 'Microsoft.Web/serverfarms@2022-09-01' = {
   name: 'plan-${name}'
@@ -75,10 +71,6 @@ resource webApp 'Microsoft.Web/sites@2022-09-01' = {
         {
           name: 'AzureAIFoundry__Endpoint'
           value: aiFoundryEndpoint
-        }
-        {
-          name: 'AzureAIFoundry__ApiKey'
-          value: aiFoundryApiKey
         }
         {
           name: 'AzureAIFoundry__ModelName'

--- a/scripts/run-local.sh
+++ b/scripts/run-local.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# run-local.sh
+# Retrieves Azure AI Foundry credentials from the deployed environment and
+# starts the ZavaStorefront application locally.
+#
+# Prerequisites:
+#   - Azure CLI (az) installed and logged in
+#   - Azure Developer CLI (azd) installed with an environment configured
+#   - .NET 10 SDK installed
+#
+# Usage:
+#   bash scripts/run-local.sh [azd-env-name]
+#
+# The azd environment name defaults to "twl300" if not provided.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SRC_DIR="$REPO_ROOT/src"
+AZD_ENV_NAME="${1:-twl300}"
+
+echo "==> Checking Azure login..."
+if ! az account show &>/dev/null; then
+  echo "   Not logged in. Starting az login..."
+  az login --use-device-code --tenant msft.flow-soft.com
+fi
+
+echo "==> Using azd environment: $AZD_ENV_NAME"
+cd "$REPO_ROOT"
+
+# Set the azd environment if not already set
+azd env select "$AZD_ENV_NAME" 2>/dev/null || true
+
+echo "==> Refreshing azd environment values from Azure..."
+azd env refresh --no-prompt 2>/dev/null || true
+
+# Try to read values from azd environment
+AI_NAME=$(azd env get-values --output json 2>/dev/null | jq -r '.AZURE_AI_FOUNDRY_NAME // empty')
+RESOURCE_GROUP=$(azd env get-values --output json 2>/dev/null | jq -r '.AZURE_RESOURCE_GROUP // empty')
+AI_ENDPOINT=$(azd env get-values --output json 2>/dev/null | jq -r '.AZURE_AI_FOUNDRY_ENDPOINT // empty')
+
+# Fall back to discovering the resource via az if azd values are missing
+if [[ -z "$AI_NAME" || -z "$RESOURCE_GROUP" ]]; then
+  echo "   azd values not found, discovering AI Services resource via az CLI..."
+  SUBSCRIPTION=$(az account show --query id -o tsv)
+  # Find any CognitiveServices account with kind=AIServices tagged for this environment
+  FOUND=$(az cognitiveservices account list \
+    --subscription "$SUBSCRIPTION" \
+    --query "[?kind=='AIServices'] | [0].{name:name, rg:resourceGroup, endpoint:properties.endpoint}" \
+    -o json 2>/dev/null || echo "[]")
+
+  AI_NAME=$(echo "$FOUND" | jq -r '.name // empty')
+  RESOURCE_GROUP=$(echo "$FOUND" | jq -r '.rg // empty')
+
+  if [[ -z "$AI_NAME" ]]; then
+    echo "ERROR: Could not find an Azure AI Services (AIServices) resource in your subscription."
+    echo "Have you run 'azd provision' yet? Or specify the correct azd environment name as an argument."
+    exit 1
+  fi
+fi
+
+# Construct the inference endpoint if not already set
+if [[ -z "$AI_ENDPOINT" ]]; then
+  AI_ENDPOINT="https://${AI_NAME}.services.ai.azure.com/"
+fi
+
+echo "==> Retrieving API key for AI Services resource: $AI_NAME (rg: $RESOURCE_GROUP)"
+AI_KEY=$(az cognitiveservices account keys list \
+  --name "$AI_NAME" \
+  --resource-group "$RESOURCE_GROUP" \
+  --query "key1" -o tsv)
+
+if [[ -z "$AI_KEY" ]]; then
+  echo "ERROR: Could not retrieve the API key for $AI_NAME."
+  exit 1
+fi
+
+echo ""
+echo "==> Configuration retrieved:"
+echo "    Endpoint  : $AI_ENDPOINT"
+echo "    Model     : Phi-4-mini-instruct"
+echo "    Key       : ${AI_KEY:0:8}...  (truncated)"
+echo ""
+
+echo "==> Starting ZavaStorefront on https://localhost:5001 ..."
+echo "    Press Ctrl+C to stop."
+echo ""
+
+cd "$SRC_DIR"
+export AzureAIFoundry__Endpoint="$AI_ENDPOINT"
+export AzureAIFoundry__ApiKey="$AI_KEY"
+export AzureAIFoundry__ModelName="Phi-4-mini-instruct"
+export ASPNETCORE_ENVIRONMENT="Development"
+
+dotnet run

--- a/scripts/run-local.sh
+++ b/scripts/run-local.sh
@@ -82,6 +82,5 @@ export AzureAIFoundry__ModelName="Phi-4-mini-instruct"
 export ASPNETCORE_ENVIRONMENT="Development"
 export Logging__LogLevel__Default="Debug"
 export Logging__LogLevel__Microsoft="Debug"
-export Logging__LogLevel__Microsoft.Hosting.Lifetime="Information"
 
 dotnet run

--- a/scripts/run-local.sh
+++ b/scripts/run-local.sh
@@ -21,9 +21,9 @@ SRC_DIR="$REPO_ROOT/src"
 AZD_ENV_NAME="${1:-twl300}"
 
 echo "==> Checking Azure login..."
-if ! az account show &>/dev/null; then
-  echo "   Not logged in. Starting az login..."
-  az login --use-device-code --tenant msft.flow-soft.com
+if ! azd auth token &>/dev/null; then
+  echo "   Not logged in. Starting azd login..."
+  azd auth login --use-device-code
 fi
 
 echo "==> Using azd environment: $AZD_ENV_NAME"
@@ -62,7 +62,7 @@ fi
 
 # Construct the inference endpoint if not already set
 if [[ -z "$AI_ENDPOINT" ]]; then
-  AI_ENDPOINT="https://${AI_NAME}.services.ai.azure.com/"
+  AI_ENDPOINT="https://${AI_NAME}.services.ai.azure.com/models"
 fi
 
 echo ""

--- a/scripts/run-local.sh
+++ b/scripts/run-local.sh
@@ -65,22 +65,11 @@ if [[ -z "$AI_ENDPOINT" ]]; then
   AI_ENDPOINT="https://${AI_NAME}.services.ai.azure.com/"
 fi
 
-echo "==> Retrieving API key for AI Services resource: $AI_NAME (rg: $RESOURCE_GROUP)"
-AI_KEY=$(az cognitiveservices account keys list \
-  --name "$AI_NAME" \
-  --resource-group "$RESOURCE_GROUP" \
-  --query "key1" -o tsv)
-
-if [[ -z "$AI_KEY" ]]; then
-  echo "ERROR: Could not retrieve the API key for $AI_NAME."
-  exit 1
-fi
-
 echo ""
 echo "==> Configuration retrieved:"
 echo "    Endpoint  : $AI_ENDPOINT"
 echo "    Model     : Phi-4-mini-instruct"
-echo "    Key       : ${AI_KEY:0:8}...  (truncated)"
+echo "    Auth      : DefaultAzureCredential (az login)"
 echo ""
 
 echo "==> Starting ZavaStorefront on https://localhost:5001 ..."
@@ -89,7 +78,6 @@ echo ""
 
 cd "$SRC_DIR"
 export AzureAIFoundry__Endpoint="$AI_ENDPOINT"
-export AzureAIFoundry__ApiKey="$AI_KEY"
 export AzureAIFoundry__ModelName="Phi-4-mini-instruct"
 export ASPNETCORE_ENVIRONMENT="Development"
 

--- a/scripts/run-local.sh
+++ b/scripts/run-local.sh
@@ -80,5 +80,8 @@ cd "$SRC_DIR"
 export AzureAIFoundry__Endpoint="$AI_ENDPOINT"
 export AzureAIFoundry__ModelName="Phi-4-mini-instruct"
 export ASPNETCORE_ENVIRONMENT="Development"
+export Logging__LogLevel__Default="Debug"
+export Logging__LogLevel__Microsoft="Debug"
+export Logging__LogLevel__Microsoft.Hosting.Lifetime="Information"
 
 dotnet run

--- a/src/Services/ChatService.cs
+++ b/src/Services/ChatService.cs
@@ -7,6 +7,7 @@ namespace ZavaStorefront.Services
     {
         private readonly ChatCompletionsClient _client;
         private readonly string _modelName;
+        private readonly string _endpoint;
         private readonly ILogger<ChatService> _logger;
         private readonly bool _isConfigured;
 
@@ -17,6 +18,7 @@ namespace ZavaStorefront.Services
             var endpoint = configuration["AzureAIFoundry:Endpoint"];
             var apiKey = configuration["AzureAIFoundry:ApiKey"];
             _modelName = configuration["AzureAIFoundry:ModelName"] ?? "Phi-4-mini-instruct";
+            _endpoint = endpoint ?? string.Empty;
 
             if (!string.IsNullOrWhiteSpace(endpoint) && !string.IsNullOrWhiteSpace(apiKey))
             {
@@ -58,8 +60,9 @@ namespace ZavaStorefront.Services
             }
             catch (RequestFailedException ex)
             {
-                _logger.LogError(ex, "Request to Azure AI Foundry endpoint failed.");
-                return "Error: Unable to get a response from the chat service at this time.";
+                _logger.LogError(ex, "Request to Azure AI Foundry endpoint failed. Status: {Status}, ErrorCode: {ErrorCode}, Endpoint: {Endpoint}",
+                    ex.Status, ex.ErrorCode, _endpoint);
+                return $"Error: Unable to get a response from the chat service at this time. (Status: {ex.Status}, Code: {ex.ErrorCode})";
             }
             catch (OperationCanceledException ex)
             {

--- a/src/ZavaStorefront.csproj
+++ b/src/ZavaStorefront.csproj
@@ -1,13 +1,15 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>14f23363-4f31-4949-9c5d-5bb815acea6d</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Azure.AI.Inference" Version="1.0.0-beta.5" />
+    <PackageReference Include="Azure.Identity" Version="1.17.1" />
   </ItemGroup>
 
 </Project>

--- a/src/appsettings.json
+++ b/src/appsettings.json
@@ -8,7 +8,6 @@
   "AllowedHosts": "*",
   "AzureAIFoundry": {
     "Endpoint": "",
-    "ApiKey": "",
     "ModelName": "Phi-4-mini-instruct"
   }
 }


### PR DESCRIPTION
This pull request updates the Azure AI Foundry integration to use Managed Identity (MSI) and DefaultAzureCredential by default, eliminating the need for API keys in both production and local development. The infrastructure and documentation are updated to reflect this change, with the app and deployment scripts now relying on Azure role assignments for authentication. Manual API key management is removed from the deployment workflow, infrastructure, and application configuration.

The most important changes are:

**Infrastructure & Deployment:**

* The Bicep infrastructure (`infra/main.bicep`, `infra/modules/appService.bicep`, `infra/modules/aiFoundry.bicep`) now assigns the Cognitive Services User role to the App Service's managed identity and outputs the new `inferenceEndpoint` for use by the app; API key outputs and parameters are removed. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L58-R59) [[2]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L80-R80) [[3]](diffhunk://#diff-a58755573462aa55dc5a13668b6e5e71f226a5e6166e5afb93467827d3007640L25-R26) [[4]](diffhunk://#diff-a58755573462aa55dc5a13668b6e5e71f226a5e6166e5afb93467827d3007640L79-L82) [[5]](diffhunk://#diff-a58755573462aa55dc5a13668b6e5e71f226a5e6166e5afb93467827d3007640R94-R109) [[6]](diffhunk://#diff-275a6ff8f62e2b7479a6de2fa97db7bff7ceaf1dbacd6b932637c89b46c4fe0fL63-R67)
* The GitHub Actions deployment workflow (`.github/workflows/deploy-app.yml`) is updated to stop retrieving or setting API keys and now configures only the AI endpoint and model name as app settings. [[1]](diffhunk://#diff-7230a3559048fcc2ba14a726875d84cc74b726e7b8003611596cc2bd92ac5581L69-L76) [[2]](diffhunk://#diff-7230a3559048fcc2ba14a726875d84cc74b726e7b8003611596cc2bd92ac5581L96-L110)

**Application Code:**

* The `ChatService` (`src/Services/ChatService.cs`) now authenticates to Azure AI Foundry using `DefaultAzureCredential` wrapped in a custom `CognitiveServicesCredential` to ensure proper token scoping; API key logic is removed. [[1]](diffhunk://#diff-544e56af2d1cfab367d34f1f3de5aa610f4f6fe260325cc58cc07ab8017127fbR3-R12) [[2]](diffhunk://#diff-544e56af2d1cfab367d34f1f3de5aa610f4f6fe260325cc58cc07ab8017127fbL18-R36) [[3]](diffhunk://#diff-544e56af2d1cfab367d34f1f3de5aa610f4f6fe260325cc58cc07ab8017127fbL40-R46) [[4]](diffhunk://#diff-544e56af2d1cfab367d34f1f3de5aa610f4f6fe260325cc58cc07ab8017127fbL61-R69) [[5]](diffhunk://#diff-544e56af2d1cfab367d34f1f3de5aa610f4f6fe260325cc58cc07ab8017127fbR78-R95)
* The application configuration (`src/appsettings.json`) no longer includes the `ApiKey` property.
* The project now references the `Azure.Identity` package and enables user secrets for local development.

**Developer Experience & Documentation:**

* A new script (`scripts/run-local.sh`) is added to simplify local development: it retrieves configuration from Azure and starts the app using your `az login` session, requiring no API keys.
* The `src/README.md` is rewritten to document the new authentication model, clarify local and production setup, and explain that MSI/DefaultAzureCredential is now the default, with API key as an optional fallback. [[1]](diffhunk://#diff-e1d5879ce3e222eb0cdd43051fb8c34c00796467acb091d0b3fa939ee3355cb5R19) [[2]](diffhunk://#diff-e1d5879ce3e222eb0cdd43051fb8c34c00796467acb091d0b3fa939ee3355cb5R132-R212)