### PR TITLE
feat: add log analytics workspace integration and diagnostic settings…

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -68,6 +68,7 @@ module aiFoundry 'modules/aiFoundry.bicep' = {
     name: 'ai-${environmentName}-${resourceToken}'
     location: location
     tags: tags
+    logAnalyticsWorkspaceId: appInsights.outputs.logAnalyticsWorkspaceId
   }
 }
 

--- a/infra/modules/aiFoundry.bicep
+++ b/infra/modules/aiFoundry.bicep
@@ -7,6 +7,9 @@ param location string
 @description('Tags to apply to the Azure AI Services resource')
 param tags object = {}
 
+@description('Resource ID of the Log Analytics workspace for diagnostic settings')
+param logAnalyticsWorkspaceId string
+
 // Azure AI Services (AI Foundry)
 resource aiServices 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
   name: name
@@ -58,6 +61,31 @@ resource phi4Deployment 'Microsoft.CognitiveServices/accounts/deployments@2024-0
   dependsOn: [
     gpt41Deployment
   ]
+}
+
+// Diagnostic Settings – send all log and metric categories to Log Analytics
+resource diagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name: '${aiServices.name}-diagnostics'
+  scope: aiServices
+  properties: {
+    workspaceId: logAnalyticsWorkspaceId
+    logs: [
+      {
+        categoryGroup: 'allLogs'
+        enabled: true
+      }
+      {
+        categoryGroup: 'audit'
+        enabled: true
+      }
+    ]
+    metrics: [
+      {
+        category: 'AllMetrics'
+        enabled: true
+      }
+    ]
+  }
 }
 
 @description('Endpoint URL for the Azure AI Services resource (standard Cognitive Services)')

--- a/infra/modules/appInsights.bicep
+++ b/infra/modules/appInsights.bicep
@@ -40,3 +40,6 @@ output instrumentationKey string = applicationInsights.properties.Instrumentatio
 
 @description('Resource ID of the Application Insights resource')
 output id string = applicationInsights.id
+
+@description('Resource ID of the Log Analytics workspace')
+output logAnalyticsWorkspaceId string = logAnalyticsWorkspace.id


### PR DESCRIPTION
This pull request enhances the Azure infrastructure provisioning scripts by enabling diagnostic logging for the AI Foundry module and improving integration with Log Analytics. The main changes involve passing the Log Analytics workspace ID between modules, configuring diagnostic settings, and updating outputs.

Integration with Log Analytics and diagnostic settings:

* Added a new `logAnalyticsWorkspaceId` parameter to the `aiFoundry.bicep` module to enable passing the Log Analytics workspace resource ID for diagnostics.
* Configured a new `diagnosticSettings` resource in `aiFoundry.bicep` to send all logs and metrics from the AI Services resource to the specified Log Analytics workspace.
* Updated the instantiation of the `aiFoundry` module in `main.bicep` to pass the Log Analytics workspace ID output from the `appInsights` module.

Module outputs:

* Added a new output `logAnalyticsWorkspaceId` to the `appInsights.bicep` module, making the Log Analytics workspace resource ID available for other modules.
[Copilot is generating a summary...]